### PR TITLE
Fix little things

### DIFF
--- a/app/javascript/controllers/location_controller.js
+++ b/app/javascript/controllers/location_controller.js
@@ -92,7 +92,8 @@ export default class extends Controller {
   initMarker() {
     this.marker = new mapboxgl.Marker({
       draggable: true,
-      color: "#E74D67"
+      color: "#E74D67",
+      anchor: "bottom"
     });
 
     this.marker.on('dragend', () => this.onDragEnd());

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -2,7 +2,6 @@ import { Controller } from "stimulus"
 
 export default class extends Controller {
   static targets = [
-    "permissionBox",
     "locationView"
   ]
   static values = {
@@ -17,28 +16,12 @@ export default class extends Controller {
     this.initMapbox();
     this.fitToMarkers();
 
-    if (this.askLocationPermissionValue == true && !localStorage.getItem("hasSeenPermissionBox")) {
-      // show permission box only if the user hasn't seen it before
-      this.showPermissionBox();
-      localStorage.setItem("hasSeenPermissionBox", true);
-    }
   }
 
-  requestPermission() {
-    // request location permission from browser
-    this.geolocate.trigger();
-    this.hidePermissionBox();
-  }
-
-  hidePermissionBox() {
-    // hides the permission box
-    this.permissionBoxTarget.style.display = "none";
-  }
-
-  showPermissionBox() {
-    // hides the permission box
-    this.permissionBoxTarget.style.display = "block";
-  }
+  // requestPermission() {
+  //   // request location permission from browser
+  //   this.geolocate.trigger();
+  // }
 
   showLocationView() {
     this.locationViewTarget.classList.remove("hidden");
@@ -70,18 +53,22 @@ export default class extends Controller {
       anchor.setAttribute("data-action", "map#showLocationView");
 
       let marker = new mapboxgl.Marker({
-        color: "#E74D67"
+        color: "#E74D67",
+        anchor: "bottom"
       });
 
       anchor.appendChild(marker.getElement())
 
-      new mapboxgl.Marker({ element: anchor })
+      new mapboxgl.Marker({ 
+        element: anchor,
+        // offset is necessary because we are using a custom element
+        offset: [-12, -35]
+      })
         .setLngLat(feature.geometry.coordinates)
         .addTo(this.map);
     }
 
     // Add geolocate control to the map.
-    // we should set track user location false for desktop
     this.geolocate = new mapboxgl.GeolocateControl({
       positionOptions: {
         enableHighAccuracy: true
@@ -94,14 +81,9 @@ export default class extends Controller {
 
     this.map.addControl(this.geolocate);
 
-    // get user's locations
-    // map.on('load', function() {
-    //   geolocate.trigger();
-    // });
-
     // add zoom buttons
     var nav = new mapboxgl.NavigationControl();
-    this.map.addControl(nav, 'bottom-right');
+    this.map.addControl(nav, "bottom-right");
 
     this.map.addControl(
       new MapboxGeocoder({

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -79,12 +79,11 @@ export default class extends Controller {
       },
     });
 
-    this.map.addControl(this.geolocate);
-
     // add zoom buttons
     var nav = new mapboxgl.NavigationControl();
     this.map.addControl(nav, "bottom-right");
 
+    // add search bar
     this.map.addControl(
       new MapboxGeocoder({
         accessToken: mapboxgl.accessToken,
@@ -92,7 +91,11 @@ export default class extends Controller {
         collapsed: false,
         marker: false,
         zoom: 15,
-      })
+      }),
+      "top-right"
      );
+
+     // add geolocation button
+     this.map.addControl(this.geolocate, "bottom-right");
   }
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -88,7 +88,7 @@ a {
 }
 
 .select--default {
-  box-shadow: 0 0 10px 2px rgba(0,0,0,.1);
+  box-shadow: 0 0 2px 1px rgba(0,0,0,.1);
   background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
   -moz-appearance: none;
   -webkit-appearance: none;

--- a/app/views/account_mailer/welcome_email.html.erb
+++ b/app/views/account_mailer/welcome_email.html.erb
@@ -6,7 +6,7 @@
   Your 14-day trial has now started. You have access to all features.<br><br>
   Getting started with your map is pretty simple. Just log in to
   <a href="<%= new_user_session_url %>">your account</a> and start
-  adding locations to your map. Once you're done, click "Go Live" and copy and paste the
+  adding locations to your map. Once you're done, click "Install Map" and copy and paste the
   displayed HTML code to your website.<br><br>
   If you have any questions, simply reply to this email.
 </p>

--- a/app/views/account_mailer/welcome_email.text.erb
+++ b/app/views/account_mailer/welcome_email.text.erb
@@ -5,7 +5,7 @@ Welcome to Mapzy!
 Your 14-day trial has now started. You have access to all features.
 
 Getting started with your map is pretty simple. Just log in to your account (<%= new_user_session_url %>) and start
-adding locations to your map. Once you're done, click "Go Live" and copy and paste the displayed HTML code to your website.
+adding locations to your map. Once you're done, click "Install Map" and copy and paste the displayed HTML code to your website.
 
 If you have any questions, simply reply to this email.
 

--- a/app/views/dashboard/accounts/_embed_code.html.erb
+++ b/app/views/dashboard/accounts/_embed_code.html.erb
@@ -5,7 +5,7 @@
   <div class="p-2 bg-gray-900 rounded my-4 w-full text-white text-sm">
     <code>
       <%=
-        %(<iframe src="#{map_url(map_id)}" title="Map by mapzy.io" loading="lazy" referrerpolicy="no-referrer" height="600px" width="100%"></iframe>)
+        %(<iframe src="#{map_url(map_id)}" allow="geolocation" title="Map by mapzy.io" loading="lazy" referrerpolicy="no-referrer" height="600px" width="100%"></iframe>)
       %>
     </code>
   </div>

--- a/app/views/dashboard/locations/_form.html.erb
+++ b/app/views/dashboard/locations/_form.html.erb
@@ -16,7 +16,7 @@
 
           <%= f.text_field :name,
                 class: "input--default",
-                placeholder: "Yeti Store",
+                placeholder: "Joe's Candy Store",
                 required: true %>
 
           <p class="input-info">Keep it short & crispy</p>

--- a/app/views/dashboard/locations/_form.html.erb
+++ b/app/views/dashboard/locations/_form.html.erb
@@ -102,12 +102,12 @@
                       <%= fot.hidden_field :location_id %>
                       <%= fot.hidden_field :day %>
 
-                      <div class="py-1 my-1 w-32">
+                      <div class="py-1 mt-1 w-32">
                         <span class="uppercase tracking-wide text-gray-700 text-xs"><%= opening_time.day %></span>
                       </div>
 
                       <div class="flex flex-row items-start justify-center">
-                        <div class="flex flex-row justify-center items-start py-1 my-1 text-sm"
+                        <div class="flex flex-row justify-center items-start py-1 mb-1 text-sm"
                             data-opening-time-target="timesBlock" >
                           <%= fot.select :opens_at,
                               options_for_select(OpeningTime.time_options, opening_time.opens_at&.strftime("%H:%M")),

--- a/app/views/dashboard/locations/_form.html.erb
+++ b/app/views/dashboard/locations/_form.html.erb
@@ -1,6 +1,9 @@
-<div class="absolute w-full md:w-2/5 overflow-y-scroll bg-white shadow-md rounded md:inset-x-0 bottom-0 md:top-0 h-1/2 md:h-auto z-20 p-6">
+<div
+  class="absolute w-full md:w-2/6 overflow-y-scroll bg-white
+        shadow-md rounded md:inset-x-0 bottom-0 md:top-0 h-1/2 md:h-auto z-20 p-6"
+>
   <h1 class="text-xl pb-6 text-center"><%= title %></h1>
-
+  
     <div data-controller="location"
          data-location-mapbox-access-token-value="<%= ENV['MAPBOX_ACCESS_TOKEN'] %>"
          data-location-bounds-value="<%= @bounds %>"
@@ -94,7 +97,7 @@
                 <%= f.fields_for "opening_times_attributes[]", opening_time do |fot| %>
 
                   <div data-controller="opening-time">
-                    <div class="flex flex-row justify-start items-start">
+                    <div class="flex flex-col justify-start items-start">
                       <%= fot.hidden_field :id %>
                       <%= fot.hidden_field :location_id %>
                       <%= fot.hidden_field :day %>
@@ -102,34 +105,36 @@
                       <div class="py-1 my-1 w-32">
                         <span class="uppercase tracking-wide text-gray-700 text-xs"><%= opening_time.day %></span>
                       </div>
-          
-                      <div class="flex flex-row justify-center items-start py-1 my-1 text-sm"
-                          data-opening-time-target="timesBlock" >
-                        <%= fot.select :opens_at,
-                            options_for_select(OpeningTime.time_options, opening_time.opens_at&.strftime("%H:%M")),
-                            { include_blank: true },
-                            { class: "select--default", "data-opening-time-target": "opensAt" } %>
-                        <div> &nbsp; &mdash; &nbsp; </div>
-                        <%= fot.select :closes_at,
-                            options_for_select(OpeningTime.time_options, opening_time.closes_at&.strftime("%H:%M")),
-                            { include_blank: true },
-                            { class: "select--default mr-6", "data-opening-time-target": "closesAt" } %>
-                      </div>
 
-                      <div class="py-1" data-opening-time-target="closedBlock" >
-                        <%= fot.check_box :closed,
-                            { checked: opening_time.closed,
-                              include_hidden: false,
-                              "data-opening-time-target": "closed" } %>
-                        <%= fot.label "Closed", class: "checkbox-label--default" %>
-                      </div>
+                      <div class="flex flex-row items-start justify-center">
+                        <div class="flex flex-row justify-center items-start py-1 my-1 text-sm"
+                            data-opening-time-target="timesBlock" >
+                          <%= fot.select :opens_at,
+                              options_for_select(OpeningTime.time_options, opening_time.opens_at&.strftime("%H:%M")),
+                              { include_blank: true },
+                              { class: "select--default", "data-opening-time-target": "opensAt" } %>
+                          <div> &nbsp; &mdash; &nbsp; </div>
+                          <%= fot.select :closes_at,
+                              options_for_select(OpeningTime.time_options, opening_time.closes_at&.strftime("%H:%M")),
+                              { include_blank: true },
+                              { class: "select--default mr-6", "data-opening-time-target": "closesAt" } %>
+                        </div>
 
-                      <div class="py-1 ml-4" data-opening-time-target="open24hBlock" >
-                        <%= fot.check_box :open_24h,
-                            { checked: opening_time.open_24h,
-                              include_hidden: false,
-                              "data-opening-time-target": "open24h" } %>
-                        <%= fot.label "Open 24h", class: "checkbox-label--default" %>
+                        <div class="py-1" data-opening-time-target="closedBlock" >
+                          <%= fot.check_box :closed,
+                              { checked: opening_time.closed,
+                                include_hidden: false,
+                                "data-opening-time-target": "closed" } %>
+                          <%= fot.label "Closed", class: "checkbox-label--default" %>
+                        </div>
+
+                        <div class="py-1 ml-4" data-opening-time-target="open24hBlock" >
+                          <%= fot.check_box :open_24h,
+                              { checked: opening_time.open_24h,
+                                include_hidden: false,
+                                "data-opening-time-target": "open24h" } %>
+                          <%= fot.label "Open 24h", class: "checkbox-label--default" %>
+                        </div>
                       </div>
                   </div>
                 </div>

--- a/app/views/dashboard/locations/edit.html.erb
+++ b/app/views/dashboard/locations/edit.html.erb
@@ -1,4 +1,8 @@
 <%= render "dashboard/layouts/main" do %>
-  <%= render "shared/mapbox" %>
+  <div class="w-full h-full flex flex-row items-center justify-end">
+    <div class="w-4/6 h-full">
+      <%= render "shared/mapbox" %>
+    </div>
+  </div>
   <%= render partial: "dashboard/locations/form", locals: { title: "Edit Location "} %>
 <% end %>

--- a/app/views/dashboard/locations/new.html.erb
+++ b/app/views/dashboard/locations/new.html.erb
@@ -1,6 +1,6 @@
 <%= render "dashboard/layouts/main" do %>
   <div class="w-full h-full flex flex-row items-center justify-end">
-    <div class="w-3/5 h-full">
+    <div class="w-4/6 h-full">
       <%= render "shared/mapbox" %>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,6 +23,22 @@
         class: "input--default" %>
     </div>
 
+    <div class="field mt-4">
+      <div class="flex flex-row items-start justify-center gap-x-4">
+        <div>
+          <%= check_box_tag "tos", "yes", false, required: true %>
+        </div>
+        <div>
+          <%= label_tag "tos",
+            %Q(
+              I have read and agree to the Mapzy 
+              <a href="https://mapzy.io/legal/terms" target="_blank">terms of service</a> and
+              <a href="https://mapzy.io/legal/privacy-policy" target="_blank">privacy policy</a>).html_safe
+          %>
+        </div>
+      </div>
+    </div>
+
     <div class="actions mt-8 mb-4">
       <%= f.submit "Sign up", class: "w-full button--main" %>
     </div>

--- a/app/views/shared/_location_permission.html.erb
+++ b/app/views/shared/_location_permission.html.erb
@@ -1,9 +1,0 @@
-<div class="absolute z-30 bg-white inset-x-24 bottom-12 rounded p-4 flex flex-col justify-center items-center hidden" data-map-target="permissionBox">
-  <div class="py-2 text-lg">
-    Please grant location permission so we can show stores in your area or search for your city on the top.
-  </div>
-  <div class="w-full flex justify-center items-center py-2 space-x-6">
-    <button class="w-1/6 button--main" data-action="click->map#requestPermission">Grant permission</button>
-    <button class="w-1/6 button--secondary" data-action="click->map#hidePermissionBox">Hide</button>
-  </div>
-</div>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -11,5 +11,4 @@
       </turbo-frame>
     </div>
     <%= render "shared/mapbox" %>
-    <%= render "shared/location_permission" %>
 </div>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -6,7 +6,11 @@
   data-map-location-base-url-value="<%= @location_base_url %>"
   data-map-ask-location-permission-value="<%= @ask_location_permission %>">
 
-    <div class="absolute w-full md:w-96 bg-white shadow-md rounded top-O bottom-0 md:top-0 md:bottom-0 h-1/2 md:h-auto z-20 hidden" data-map-target="locationView">
+    <div
+      class="absolute w-full md:w-96 bg-white shadow-md border-gray-200 border-l-2 border-t-2 border-b-2
+            rounded top-O bottom-0 md:top-0 md:bottom-0 h-1/2 md:h-auto z-20 hidden"
+      data-map-target="locationView"
+    >
       <turbo-frame id="locations_show">
       </turbo-frame>
     </div>

--- a/spec/features/interact_with_map_spec.rb
+++ b/spec/features/interact_with_map_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe "interacting with the map", type: :feature do
     visit map_path(map.id)
   end
 
-  it "shows permission box" do
-    expect(page).to have_selector(:link_or_button, "Grant permission")
-  end
-
-  it "hides permission box on hide click" do
-    page.find_button("Hide").click
-    expect(page).not_to have_selector(:link_or_button, "Grant permission")
-  end
-
   it "does not show location name before click" do
     expect(page).not_to have_content(location.name)
   end


### PR DESCRIPTION
Tada! This fixes:
- Checkbox on sign up with terms (only implemented client-side, would need to replace Devise `User#create` completely otherwise and not worth it right now)
- Welcome email text ("Install Map" instead of "Go Live")
- Markers are anchored at the correct coordinates
- Removed geolocation permission pop-up
- Added `allow="geolocation"` to iframe embed code
- Added border to show location panel so that it looks better on embedded sites with white background (didn't actually test how it looks now, yolo)
- Rearranged map elements on map (see screenshot)
- Improved add location form so that it also looks good on smaller device widths (e.g. my old MacBook, see screenshot)

Moved geolocation button to the bottom right, it was looking akward with the search bar and the search bar was covering a good portion of the map:
<img width="1440" alt="Screenshot 2021-11-20 at 15 15 43" src="https://user-images.githubusercontent.com/1881676/142730218-ffda733b-9109-4b44-a763-dc040e0500d9.png">

Opening times select fields are now below the day of the week name. This also allowed me to decrease the width of the left panel and have more space for the map.
<img width="1440" alt="Screenshot 2021-11-20 at 15 12 42" src="https://user-images.githubusercontent.com/1881676/142730221-a9f6875a-4302-4d0e-be81-e8474a6ce865.png">

Let me know what you think!
