### PR TITLE
fix: map is not always centered on markers on load

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -12,25 +12,6 @@ export default class extends Controller {
   }
 
   initialize() {
-    this.initMapbox();
-    this.fitToMarkers();
-
-  }
-
-  showLocationView() {
-    this.locationViewTarget.classList.remove("hidden");
-  }
-
-  hideLocationView() {
-    this.locationViewTarget.classList.add("hidden");
-  }
-
-  fitToMarkers() {
-    this.map.fitBounds(this.boundsValue, {padding: 50, maxZoom: 12});
-   }
-
-  initMapbox() {
-    // get access token
     mapboxgl.accessToken = this.mapboxAccessTokenValue;
     
     this.map = new mapboxgl.Map({
@@ -77,7 +58,6 @@ export default class extends Controller {
     var nav = new mapboxgl.NavigationControl();
     this.map.addControl(nav, "bottom-right");
 
-
     // add geolocation button
     this.map.addControl(this.geolocate, "bottom-right");
 
@@ -93,5 +73,15 @@ export default class extends Controller {
       "top-right"
      );
 
+    // Fit to markers
+    this.map.fitBounds(this.boundsValue, {padding: 50, maxZoom: 12});
+  }
+
+  showLocationView() {
+    this.locationViewTarget.classList.remove("hidden");
+  }
+
+  hideLocationView() {
+    this.locationViewTarget.classList.add("hidden");
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -17,6 +17,8 @@ export default class extends Controller {
     this.map = new mapboxgl.Map({
       container: 'map',
       style: 'mapbox://styles/mapbox/streets-v11',
+      bounds: this.boundsValue,
+      fitBoundsOptions: { padding: 50, maxZoom: 12 }
     });
 
     // create markers
@@ -72,9 +74,6 @@ export default class extends Controller {
       }),
       "top-right"
      );
-
-    // Fit to markers
-    this.map.fitBounds(this.boundsValue, {padding: 50, maxZoom: 12});
   }
 
   showLocationView() {


### PR DESCRIPTION
I think the problem is: the .fitBounds method is sometimes executed before the map has loaded (coucou JS event loop). Mapbox offers to set bounds directly during the map instanciation, which should solve the issue if my assumption is right.

Can you give it a run?

Closes #33 