### PR TITLE
fix: use hashid also for edit / delete links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "sidekiq", "~> 6.4"
 gem "faraday", "~> 1.8.0"
 
 # Utility to use short hash IDs instead of the database IDs
-gem "hashid-rails", "~> 1.0"
+gem "hashid-rails", "~> 1.4"
 
 gem "tailwindcss-rails", "~> 2.0.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ DEPENDENCIES
   foreman (~> 0.87.2)
   geocoder (~> 1.6)
   guard-rspec
-  hashid-rails (~> 1.0)
+  hashid-rails (~> 1.4)
   importmap-rails (~> 1.0.2)
   jbuilder (~> 2.7)
   letter_opener

--- a/app/views/dashboard/locations/show.html.erb
+++ b/app/views/dashboard/locations/show.html.erb
@@ -12,7 +12,7 @@
 
     <div class="relative w-full mt-8">
       <div class="flex-auto flex space-x-6">
-        <%= button_to "Delete", dashboard_map_location_path(map_id: @map.id, id: @location.id),
+        <%= button_to "Delete", dashboard_map_location_path(map_id: @map.hashid, id: @location.hashid),
             data: { turbo_frame: "_top" },
             form: {
               data: { turbo_confirm: "Once deleted, it's deleted! Are you sure you want to delete this location?" },
@@ -23,7 +23,7 @@
             class: "w-full button--secondary"
         %>
 
-        <%= link_to "Edit", edit_dashboard_map_location_path(map_id: @map.id, id: @location.id),
+        <%= link_to "Edit", edit_dashboard_map_location_path(map_id: @map.hashid, id: @location.hashid),
               target: "_top",
               class: "w-1/2 button--main" %>
       </div>

--- a/spec/requests/dashboard/locations_spec.rb
+++ b/spec/requests/dashboard/locations_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Locations", type: :request do
 
   describe "GET locations/new" do
     it "responds with a HTTP 200" do
-      get new_dashboard_map_location_path(map_id: map.id)
+      get new_dashboard_map_location_path(map_id: map.hashid)
       expect(response).to be_successful
     end
   end
 
   describe "GET locations/show" do
     before do
-      get dashboard_map_location_path(map_id: map.id, id: location.id)
+      get dashboard_map_location_path(map_id: map.hashid, id: location.hashid)
     end
 
     it "responds with a HTTP 200" do


### PR DESCRIPTION
This small PR makes sure we don't expose the internal IDs for maps / locations anywhere (use hashid instead)