### PR TITLE
fix: colors & borders of the location edit/add form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.8)
+    nokogiri (1.13.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,8 +3,36 @@
 @tailwind utilities;
 @tailwind screens;
 
-/* Base styles */
+/* Custom Variables */
+:root {
+  --black: #000;
+}
 
+/* Override default focus colors for tailwindcss-forms
+https://github.com/tailwindlabs/tailwindcss-forms */
+[type='text']:focus,
+[type='email']:focus,
+[type='url']:focus,
+[type='password']:focus,
+[type='number']:focus,
+[type='date']:focus,
+[type='datetime-local']:focus,
+[type='month']:focus,
+[type='search']:focus,
+[type='tel']:focus,
+[type='checkbox']:focus,
+[type='radio']:focus,
+[type='time']:focus,
+[type='week']:focus,
+[multiple]:focus,
+textarea:focus,
+select:focus {
+  color: var(--black);
+  --tw-ring-color: var(--black);
+  border-color: var(--black);
+}
+
+/* Base styles */
 h1 {
 	@apply text-3xl leading-7 font-bold
 }
@@ -43,13 +71,11 @@ code {
 }
 
 /* Emphasis */
-
 .underline-red {
   @apply border-b-4 border-mapzy-red-light
 }
 
 /* Flash messages */
-
 .flash {
   @apply flex flex-row items-center justify-between w-full p-4 border-2 text-mapzy-violet bg-blue-50 rounded
 }
@@ -86,10 +112,6 @@ code {
   @apply block w-full rounded py-3 px-4 mb-1 leading-tight
 }
 
-.input--default:focus {
-  @apply border-black ring-black ring-1
-}
-
 .input-info {
   @apply text-gray-600 text-xs italic
 }
@@ -100,18 +122,6 @@ code {
   -webkit-appearance: none;
   appearance: none;
   @apply pr-4 pl-2 rounded bg-white text-gray-700
-}
-
-.select--default:focus, .select--default:focus-within, .select--default:focus-visible {
-  @apply border-black ring-black ring-1
-}
-
-.checkbox--default {
-  @apply text-black
-}
-
-.checkbox--default:focus {
-  @apply border-black ring-black ring-1
 }
 
 .checkbox-label--default {
@@ -130,12 +140,11 @@ code {
 
 .mapboxgl-ctrl-geocoder:focus-within {
   border-color: #000;
-  box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   --tw-ring-color: #000;
+  box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
 }
 
 .mapboxgl-ctrl-geocoder--input {
-  color: #000 !important;
   border-radius: .25rem;
   display: block;
   line-height: 1.25;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -123,7 +123,7 @@ code {
   border-width: 1px !important;
   width: 100% !important;
   max-width: none !important;
-  padding-left: 25px !important;
+  padding-left: 30px !important;
   box-shadow: none;
   border-color: #6b7280;
 }
@@ -139,8 +139,6 @@ code {
   border-radius: .25rem;
   display: block;
   line-height: 1.25;
-  margin-bottom: .25rem;
-  padding: .75rem 1rem;
   width: 100%;
   box-shadow: none !important;
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -83,7 +83,11 @@ code {
 }
 
 .input--default {
-  @apply block w-full rounded py-3 px-4 mb-1 leading-tight border-2
+  @apply block w-full rounded py-3 px-4 mb-1 leading-tight
+}
+
+.input--default:focus {
+  @apply border-black ring-black ring-1
 }
 
 .input-info {
@@ -95,7 +99,19 @@ code {
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
-  @apply pr-4 pl-2 rounded bg-white text-gray-700 border-2
+  @apply pr-4 pl-2 rounded bg-white text-gray-700
+}
+
+.select--default:focus, .select--default:focus-within, .select--default:focus-visible {
+  @apply border-black ring-black ring-1
+}
+
+.checkbox--default {
+  @apply text-black
+}
+
+.checkbox--default:focus {
+  @apply border-black ring-black ring-1
 }
 
 .checkbox-label--default {
@@ -104,18 +120,27 @@ code {
 
 /* Mapbox */
 .mapboxgl-ctrl-geocoder {
-  border-width: 2px !important;
+  border-width: 1px !important;
   width: 100% !important;
   max-width: none !important;
-  box-shadow: none !important;
-  padding-left: 20px;
+  padding-left: 25px !important;
+  box-shadow: none;
+  border-color: #6b7280;
 }
 
 .mapboxgl-ctrl-geocoder:focus-within {
-  border-color: #2563eb;
+  border-color: #000;
+  box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  --tw-ring-color: #000;
 }
 
-.mapboxgl-ctrl-geocoder--input:focus {
-  box-shadow: none;
-  outline: none;
+.mapboxgl-ctrl-geocoder--input {
+  color: #000 !important;
+  border-radius: .25rem;
+  display: block;
+  line-height: 1.25;
+  margin-bottom: .25rem;
+  padding: .75rem 1rem;
+  width: 100%;
+  box-shadow: none !important;
 }

--- a/app/javascript/controllers/location_controller.js
+++ b/app/javascript/controllers/location_controller.js
@@ -84,9 +84,6 @@ export default class extends Controller {
 
     // Turn off autocomplete
     this.addressInput.autocomplete = "off";
-
-    // Suit up bro
-    this.addressInput.classList.add('input--default')
   }
 
   initMarker() {

--- a/app/views/dashboard/locations/_form.html.erb
+++ b/app/views/dashboard/locations/_form.html.erb
@@ -119,8 +119,7 @@
                           <%= fot.check_box :closed,
                               { checked: opening_time.closed,
                                 include_hidden: false,
-                                "data-opening-time-target": "closed",
-                                class: "checkbox--default" } %>
+                                "data-opening-time-target": "closed" } %>
                           <%= fot.label "Closed", class: "checkbox-label--default" %>
                         </div>
 
@@ -128,8 +127,7 @@
                           <%= fot.check_box :open_24h,
                               { checked: opening_time.open_24h,
                                 include_hidden: false,
-                                "data-opening-time-target": "open24h",
-                                class: "checkbox--default" } %>
+                                "data-opening-time-target": "open24h" } %>
                           <%= fot.label "Open 24h", class: "checkbox-label--default" %>
                         </div>
                       </div>

--- a/app/views/dashboard/locations/_form.html.erb
+++ b/app/views/dashboard/locations/_form.html.erb
@@ -119,7 +119,8 @@
                           <%= fot.check_box :closed,
                               { checked: opening_time.closed,
                                 include_hidden: false,
-                                "data-opening-time-target": "closed" } %>
+                                "data-opening-time-target": "closed",
+                                class: "checkbox--default" } %>
                           <%= fot.label "Closed", class: "checkbox-label--default" %>
                         </div>
 
@@ -127,7 +128,8 @@
                           <%= fot.check_box :open_24h,
                               { checked: opening_time.open_24h,
                                 include_hidden: false,
-                                "data-opening-time-target": "open24h" } %>
+                                "data-opening-time-target": "open24h",
+                                class: "checkbox--default" } %>
                           <%= fot.label "Open 24h", class: "checkbox-label--default" %>
                         </div>
                       </div>


### PR DESCRIPTION
This small PR fixes the colors & borders of the location edit/add form. Some swag got lost with the previous tailwindcss upgrade. 

Before:
<img width="576" alt="Screenshot 2022-04-14 at 23 43 09" src="https://user-images.githubusercontent.com/6225080/163481623-714d4de9-857e-4d2c-b933-1cc9be6ff3b9.png">


After:
<img width="575" alt="Screenshot 2022-04-14 at 23 43 25" src="https://user-images.githubusercontent.com/6225080/163481637-2ad92345-498a-4c1a-9e55-bfcfde33e6a5.png">

