### PR TITLE
fix: clear flash after it has been rendered

### DIFF
--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -13,3 +13,4 @@
     </div>
   <% end %>
 <% end %>
+<% flash.clear %>

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "Registrations", type: :request do
       end
 
       it "show correct error message in HTML" do
-        expect(flash[:alert]).to include("Password confirmation doesn't match Password")
+        expect(response.body).to include("Password confirmation doesn't match Password")
       end
     end
   end


### PR DESCRIPTION
Closes #51 

I couldn't reproduce the error locally, so I have deployed this to production once to check.

Before:
Visiting https://app.mapzy.io/dashboard/maps/ZxOHrm then https://app.mapzy.io/maps/ZxOHrm would keep the flash on

After:
Not anymore