### PR TITLE
Add custom colors and flash improvements

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -32,6 +32,25 @@ select:focus {
   border-color: var(--black);
 }
 
+input[type="color"] {
+  border-start-start-radius: 0.25rem;
+  padding: 0;
+  border: 0.25rem solid rgb(226 232 240);
+}
+
+input[type="color"]::-moz-color-swatch {
+  border: none;
+}
+
+input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+  border-radius: 0;
+}
+
+input[type="color"]::-webkit-color-swatch {
+  border: none;
+}
+
 /* Base styles */
 h1 {
   @apply text-3xl leading-7 font-bold
@@ -76,7 +95,11 @@ code {
 }
 
 /* Flash messages */
-.flash {
+.flash-alert {
+  @apply flex flex-row items-center justify-between w-full p-4 border-2 text-black bg-red-100 rounded
+}
+
+.flash-notice {
   @apply flex flex-row items-center justify-between w-full p-4 border-2 text-mapzy-violet bg-blue-50 rounded
 }
 

--- a/app/controllers/dashboard/accounts_controller.rb
+++ b/app/controllers/dashboard/accounts_controller.rb
@@ -20,6 +20,12 @@ module Dashboard
 
     def embed; end
 
+    def update
+      return head :ok, content_type: "text/html" if @account.update(acccount_params)
+
+      render "_update_error", status: :unprocessable_content
+    end
+
     private
 
     def format_cancel_time(unix_time)

--- a/app/controllers/dashboard/maps_controller.rb
+++ b/app/controllers/dashboard/maps_controller.rb
@@ -21,9 +21,27 @@ module Dashboard
     end
 
     def update
-      return head :ok, content_type: "text/html" if @map.update(map_params)
+      if @map.update(map_params)
+        streams = [
+        render_turbo_stream_flash_message(
+          "notice",
+          "Settings saved!"
+        )
+      ]
+      else
+        streams = [
+        render_turbo_stream_flash_message(
+          "alert",
+          "Error saving settings: #{@map.errors.full_messages}"
+        )
+      ]
+      end
 
-      render "_update_error", status: :unprocessable_content
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: streams
+        end
+      end
     end
 
     private
@@ -33,7 +51,7 @@ module Dashboard
     end
 
     def map_params
-      params.require(:map).permit(:id, :sync_mode)
+      params.require(:map).permit(:id, :sync_mode, :custom_color, :custom_accent_color)
     end
   end
 end

--- a/app/controllers/dashboard/maps_controller.rb
+++ b/app/controllers/dashboard/maps_controller.rb
@@ -21,21 +21,21 @@ module Dashboard
     end
 
     def update
-      if @map.update(map_params)
-        streams = [
-        render_turbo_stream_flash_message(
-          "notice",
-          "Settings saved!"
-        )
-      ]
-      else
-        streams = [
-        render_turbo_stream_flash_message(
-          "alert",
-          "Error saving settings: #{@map.errors.full_messages}"
-        )
-      ]
-      end
+      streams = if @map.update(map_params)
+                  [
+                    render_turbo_stream_flash_message(
+                      "notice",
+                      "Settings saved!"
+                    )
+                  ]
+                else
+                  [
+                    render_turbo_stream_flash_message(
+                      "alert",
+                      "Error saving settings: #{@map.errors.full_messages}"
+                    )
+                  ]
+                end
 
       respond_to do |format|
         format.turbo_stream do

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,4 +3,25 @@
 class DashboardController < ApplicationController
   # Authentication with Devise
   before_action :authenticate_user!
+
+  def render_turbo_stream_flash_message(type, message, action = :update)
+    case action
+    when :update
+      turbo_stream.update(
+        :flash,
+        partial: "shared/flash_#{type}",
+        locals: { message: message }
+      )
+    when :prepend
+      turbo_stream.prepend(
+        :flash,
+        partial: "shared/flash_#{type}",
+        locals: { message: message }
+      )
+    end
+  end
+
+  def render_turbo_stream_clear_flash
+    turbo_stream.update(:flash, "")
+  end
 end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -36,8 +36,8 @@ module IconsHelper
 
   def close_icon(size: 12)
     "<svg xmlns='http://www.w3.org/2000/svg' width=#{size.to_i} height=#{size.to_i} fill='currentColor' class='bi bi-x-lg' viewBox='0 0 16 16'>
-      <path fill-rule='evenodd' d='M13.854 2.146a.5.5 0 0 1 0 .708l-11 11a.5.5 0 0 1-.708-.708l11-11a.5.5 0 0 1 .708 0Z'/>
-      <path fill-rule='evenodd' d='M2.146 2.146a.5.5 0 0 0 0 .708l11 11a.5.5 0 0 0 .708-.708l-11-11a.5.5 0 0 0-.708 0Z'/>
+      <path fill-rule='evenodd' d='M13.854 2.146a.5.5 0 0 1 0 .708l-11 11a.5.5 0 0 1-.708-.708l11-11a.5.5 0 0 1 .708 0Z' />
+      <path fill-rule='evenodd' d='M2.146 2.146a.5.5 0 0 0 0 .708l11 11a.5.5 0 0 0 .708-.708l-11-11a.5.5 0 0 0-.708 0Z' />
     </svg>".html_safe
   end
 end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -4,10 +4,16 @@ export default class extends Controller {
   static targets = ["message"]
 
   connect() {
-    setTimeout(() => this.dismiss(), 30000);
+    this.timer = setTimeout(() => {
+      this.dismiss();
+    }, 10000);
   }
 
   dismiss() {
-    this.messageTarget.classList.add("hidden");
+    this.messageTarget.remove();
+  }
+
+  disconnect() {
+    clearTimeout(this.timer);
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -7,7 +7,9 @@ export default class extends Controller {
     "bounds": Array,
     "locationBaseUrl": String,
     "dashboard": Boolean,
-    "paramNoAccidentalZoom": Boolean
+    "paramNoAccidentalZoom": Boolean,
+    "customColor": String,
+    "customAccentColor": String
   }
 
   initialize() {
@@ -89,16 +91,16 @@ export default class extends Controller {
       anchor.setAttribute("data-location-id", locationId);
 
       const marker = new mapboxgl.Marker({
-        color: "#E74D67",
+        color: this.customColorValue,
         anchor: "bottom"
       });
 
       const markerElement = marker.getElement();
 
       anchor.appendChild(markerElement);
-      anchor.addEventListener('click', this.moveMapOnHiddenMarker.bind(this));
-      anchor.addEventListener('mouseenter', () => this.toggleHighlightMarker(markerElement));
-      anchor.addEventListener('mouseleave', () => this.toggleHighlightMarker(markerElement));
+      anchor.addEventListener("click", this.moveMapOnHiddenMarker.bind(this));
+      anchor.addEventListener("mouseenter", () => this.toggleHighlightMarker(markerElement));
+      anchor.addEventListener("mouseleave", () => this.toggleHighlightMarker(markerElement));
 
       this.markerAnchors.push(anchor);
 
@@ -130,13 +132,11 @@ export default class extends Controller {
     return this.markerAnchors.find(marker => marker.getAttribute("data-location-id") === locationId);
   }
 
-  toggleHighlightMarker(markerElement) {
+  toggleHighlightMarker(markerElement, customColor, customAccentColor) {
     const svg = markerElement.firstChild;
     const path = svg.querySelector('path');
     const currentColor = path.getAttribute('fill');
-    const normalColor = "#E74D67";
-    const highlightColor = "#F99B46"
 
-    path.setAttribute('fill', currentColor === normalColor ? highlightColor : normalColor);
+    path.setAttribute('fill', currentColor === this.customColorValue ? this.customAccentColorValue : this.customColorValue);
   }
 }

--- a/app/javascript/controllers/side_panel_controller.js
+++ b/app/javascript/controllers/side_panel_controller.js
@@ -5,6 +5,11 @@ export default class extends Controller {
     "panel"
   ]
 
+  static values = {
+    "customColor": String,
+    "customAccentColor": String
+  }
+
   hidePanel() {
     this.panelTarget.classList.add("hidden");
   }

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -4,12 +4,14 @@
 #
 # Table name: maps
 #
-#  id         :bigint           not null, primary key
-#  name       :string
-#  sync_mode  :boolean          default(FALSE), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id                  :bigint           not null, primary key
+#  custom_accent_color :string           default("#f99b46"), not null
+#  custom_color        :string           default("#e74d67"), not null
+#  name                :string
+#  sync_mode           :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint           not null
 #
 # Indexes
 #
@@ -26,6 +28,10 @@ class Map < ApplicationRecord
   has_many :locations, dependent: :destroy
   has_many :payload_dumps, class_name: "Sync::PayloadDump", dependent: :destroy
   has_one :api_key, dependent: :destroy
+
+
+  validates :custom_color, presence: true
+  validates :custom_accent_color, presence: true
 
   after_create :create_api_key
 

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -29,7 +29,6 @@ class Map < ApplicationRecord
   has_many :payload_dumps, class_name: "Sync::PayloadDump", dependent: :destroy
   has_one :api_key, dependent: :destroy
 
-
   validates :custom_color, presence: true
   validates :custom_accent_color, presence: true
 

--- a/app/views/dashboard/accounts/settings.html.erb
+++ b/app/views/dashboard/accounts/settings.html.erb
@@ -1,4 +1,4 @@
-d<%= render "dashboard/layouts/main" do %>
+<%= render "dashboard/layouts/main" do %>
   <div class="flex flex-col justify-center items-center p-4 text-lg">
     <h1 class="mt-12 mb-8"><span class="underline-red">Settings</span></h1>
 
@@ -11,7 +11,49 @@ d<%= render "dashboard/layouts/main" do %>
           <% else %>
             <%= render "subscription_management" %>
           <% end %>
-        <% end %>        
+        <% end %>      
+
+        <h2 class="mt-6 mb-1">Custom colours</h2>
+        <%= form_with model: @map,
+          url: dashboard_map_path(@map),
+          method: :put,
+          data: { turbo_stream: "true" } do |form| %>
+          <p>
+            Set your own colours for pins and buttons. The accent colour is for example used
+            when a user hovers over a pin on the map.
+          </p>
+
+          <div class="flex flex-row items-center justify-start mt-4">
+            <%= form.color_field :custom_color,
+              value: @map.custom_color,
+              class: "rounded-s h-[2.5rem] hover:cursor-pointer",
+              onchange: "document.querySelector('#custom_color_value').innerText = this.value; this.form.requestSubmit();"
+            %>
+            <div
+              onclick="document.querySelector('#map_custom_color').click();"
+              id="custom_color_value"
+              class="flex items-center justify-start pl-2 rounded-e bg-slate-200 h-[2.5rem] w-[5rem] text-sm hover:cursor-pointer">
+              <%= @map.custom_color %>
+            </div>
+            <%= label_tag "account_custom_color", "Main color", class:"ml-4" %>
+          </div>
+
+          <div class="flex flex-row items-center justify-start mt-2">
+            <%= form.color_field :custom_accent_color,
+              value: @map.custom_accent_color,
+              class: "rounded-s h-[2.5rem] hover:cursor-pointer",
+              onchange: "document.querySelector('#custom_accent_color_value').innerText = this.value; this.form.requestSubmit();"
+            %>
+            <div
+              onclick="document.querySelector('#map_custom_accent_color').click();"
+              id="custom_accent_color_value"
+              class="flex items-center justify-start pl-2 rounded-e bg-slate-200 h-[2.5rem] w-[5rem] text-sm hover:cursor-pointer">
+              <%= @map.custom_accent_color %>
+            </div>
+            <%= label_tag "account_custom_accent_color", "Accent color", class:"ml-4" %>
+          </div>
+        <% end %>
+
 
         <h2 class="mt-6">Sync mode (advanced)</h2>
         <p>
@@ -25,7 +67,7 @@ d<%= render "dashboard/layouts/main" do %>
         <%= form_with model: @map,
           url: dashboard_map_path(@map),
           method: :put,
-          data: { turbo_frame: "sync_mode" } do |form| %>
+          data: { turbo_stream: "true" } do |form| %>
           <div class="flex flex-row items-center justify-start gap-x-4 mt-4">
             <label class="switch">
               <%= form.check_box :sync_mode, class: "opacity-0 w-0 h-0", onclick: "this.form.requestSubmit()" %>
@@ -36,11 +78,6 @@ d<%= render "dashboard/layouts/main" do %>
             </div>
           </div>
         <% end %>
-        <div class="text-mapzy-red mt-2">
-          <turbo-frame id='sync_mode'>
-          </turbo-frame>
-        </div>
-
         <div class="code--multiline w-fit">
           <code>
             <%= current_user.map.api_key.key_value %>

--- a/app/views/dashboard/maps/_update_error.html.erb
+++ b/app/views/dashboard/maps/_update_error.html.erb
@@ -1,4 +1,0 @@
-<turbo-frame id="sync_mode">
-  Something went wrong: <%= @map.errors.full_messages %><br>
-  Please try again.
-</turbo-frame>

--- a/app/views/shared/_all_locations_button.html.erb
+++ b/app/views/shared/_all_locations_button.html.erb
@@ -1,5 +1,18 @@
+<% content_for :head do %>
+  <style>
+    .all-locations-button {
+      background-color: <%= @map.custom_color %>;
+    }
+
+    .all-locations-button:hover {
+      background-color: <%= @map.custom_accent_color %>;
+      color: #fff;
+    }
+  </style>
+<% end %>
+
 <%= link_to shared_locations_path(@map.id),
     data: { "turbo-frame": "side_panel", "action": "side-panel#showPanel" },
-    class: "absolute bottom-12 left-3 z-10 p-3 rounded-full text-xl text-white bg-mapzy-red hover:text-white hover:bg-mapzy-red-light" do %>
+    class: "absolute bottom-12 left-3 z-10 p-3 rounded-full text-xl text-white all-locations-button" do %>
   <%= list_view_icon(size: 16) %>
 <% end %>

--- a/app/views/shared/_flash_alert.html.erb
+++ b/app/views/shared/_flash_alert.html.erb
@@ -1,0 +1,8 @@
+<div data-controller="flash" data-flash-target="message" class="flash-alert">
+  <div class="sm:inline w-[95%] text-center"><%= message.to_s.html_safe %></div>
+  <div class="w-[5%] text-sm text-center underline cursor-pointer">
+    <button data-action="flash#dismiss">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+</div>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,19 +1,5 @@
-<% if flash.any? %>
-  <div class="absolute z-50 w-full md:max-w-2xl top-20 md:top-7 left-1/2 transform -translate-x-1/2 px-4 sm:p-0">
-    <% flash.each do |key, value| %>
-      <% if value.present? %>
-        <div data-controller="flash">
-          <div data-flash-target="message" class="mb-4">
-            <div class="flash">
-              <span class="sm:inline"><%= value.to_s.html_safe %></span>
-              <button data-action="flash#dismiss">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-    <% flash.clear %>
-  </div>
-<% end %>
+<div id="flash" class="fixed top-0 inset-x-0 z-50">
+  <% flash.each do |type, message| %>
+     <%= render partial: "shared/flash_#{type}", locals: { message: message } %>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_notice.html.erb
+++ b/app/views/shared/_flash_notice.html.erb
@@ -1,0 +1,8 @@
+<div data-controller="flash" data-flash-target="message" class="flash-notice">
+  <div class="sm:inline w-[95%] text-center"><%= message.to_s.html_safe %></div>
+  <div class="w-[5%] text-sm text-center underline cursor-pointer">
+    <button data-action="flash#dismiss">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+</div>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -6,7 +6,12 @@
   data-map-location-base-url-value="<%= shared_locations_path(@map.hashid) %>"
   data-map-ask-location-permission-value="<%= @ask_location_permission %>"
   data-map-dashboard-value="<%= controller.controller_path.include?('dashboard') %>"
-  data-map-param-no-accidental-zoom-value="<%= params[:no_accidental_zoom] == "true" %>">
+  data-map-param-no-accidental-zoom-value="<%= params[:no_accidental_zoom] == "true" %>"
+  data-map-custom-color-value="<%= @map.custom_color %>"
+  data-map-custom-accent-color-value="<%= @map.custom_accent_color %>"
+  data-side-panel-custom-color-value="<%= @map.custom_color %>"
+  data-side-panel-custom-accent-color-value="<%= @map.custom_accent_color %>"
+>
 
   <%= render "shared/mapbox" %>
 

--- a/app/views/shared/_side_panel.html.erb
+++ b/app/views/shared/_side_panel.html.erb
@@ -1,9 +1,25 @@
+<% content_for :head do %>
+  <style>
+    .side-panel-close-button {
+      color: <%= @map.custom_color %>;
+    }
+
+    .side-panel-close-button:hover {
+      color: <%= @map.custom_accent_color %>;
+    }
+  </style>
+<% end %>
+
 <div data-side-panel-target="panel"
      class="absolute w-full md:w-96 bg-white border-gray-200 border-2 md:border-r-0
-            inset-x-0 bottom-0 md:top-0 md:bottom-0 h-1/2 md:h-auto z-20 hidden">
+            inset-x-0 bottom-0 md:top-0 md:bottom-0 h-1/2 md:h-auto z-20 hidden"
+>
 
-  <div class="absolute top-2 right-2">
-    <a class="block" data-action="side-panel#hidePanel">
+  <div class="absolute top-4 right-4">
+    <a
+      class="block side-panel-close-button"
+      data-action="side-panel#hidePanel"
+    >
       <%= close_icon(size: 20) %>
     </a>
   </div>

--- a/db/migrate/20240612125027_add_color_to_account.rb
+++ b/db/migrate/20240612125027_add_color_to_account.rb
@@ -1,0 +1,6 @@
+class AddColorToAccount < ActiveRecord::Migration[7.1]
+  def change
+    add_column :maps, :custom_color, :string, null: false, default: "#e74d67"
+    add_column :maps, :custom_accent_color, :string, null: false, default: "#f99b46"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_145648) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_12_125027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_145648) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "sync_mode", default: false, null: false
+    t.string "custom_color", default: "#e74d67", null: false
+    t.string "custom_accent_color", default: "#f99b46", null: false
     t.index ["user_id"], name: "index_maps_on_user_id"
   end
 

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -4,12 +4,14 @@
 #
 # Table name: maps
 #
-#  id         :bigint           not null, primary key
-#  name       :string
-#  sync_mode  :boolean          default(FALSE), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id                  :bigint           not null, primary key
+#  custom_accent_color :string           default("#f99b46"), not null
+#  custom_color        :string           default("#e74d67"), not null
+#  name                :string
+#  sync_mode           :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint           not null
 #
 # Indexes
 #

--- a/spec/requests/dashboard/accounts_spec.rb
+++ b/spec/requests/dashboard/accounts_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe "Accounts", type: :request do
   let(:user) { create(:user, account: create(:account), map: create(:map)) }
 
   before do
+    @mapzy_cloud_env_before = ENV["MAPZY_CLOUD"]
+    ENV["MAPZY_CLOUD"] = "true" 
     sign_in user
+  end
+
+  after do
+    ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before
   end
 
   describe "GET /dashboard/settings" do

--- a/spec/requests/dashboard/accounts_spec.rb
+++ b/spec/requests/dashboard/accounts_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "Accounts", type: :request do
       it "contains the start subscription link" do
         expect(response.body).to include('href="/stripe/checkout_session?sub=mini"')
       end
+
+      it "contains the main color text" do
+        expect(response.body).to include("Main color")
+      end
+
+       it "contains the accent color text" do
+        expect(response.body).to include("Accent color")
+      end
     end
 
     # context "with active account" do

--- a/spec/requests/dashboard/maps_spec.rb
+++ b/spec/requests/dashboard/maps_spec.rb
@@ -63,5 +63,43 @@ RSpec.describe "Maps", type: :request do
         expect(Map.find(map.id).sync_mode).to be false
       end
     end
+
+    context "with changing main color" do
+      let(:color_map) { { id: map.id, custom_color: "#fff" } }
+
+      before do
+        map.custom_color = "#000"
+        map.save
+      end
+
+      it "responds with a HTTP 200" do
+        patch dashboard_map_path(id: map.id, params: { map: color_map }), as: :turbo_stream
+        expect(response).to be_successful
+      end
+
+      it "updates sync mode in database" do
+        patch dashboard_map_path(id: map.id, params: { custom_color: "#000" }), as: :turbo_stream
+         expect(Map.find(map.id).custom_color).to eq("#000")
+      end
+    end
+
+    context "with changing accent color" do
+      let(:color_map) { { id: map.id, custom_color: "#fff" } }
+
+      before do
+        map.custom_accent_color = "#000"
+        map.save
+      end
+
+      it "responds with a HTTP 200" do
+        patch dashboard_map_path(id: map.id, params: { map: color_map }), as: :turbo_stream
+        expect(response).to be_successful
+      end
+
+      it "updates sync mode in database" do
+        patch dashboard_map_path(id: map.id, params: { custom_accent_color: "#000" }), as: :turbo_stream
+         expect(Map.find(map.id).custom_accent_color).to eq("#000")
+      end
+    end
   end
 end

--- a/spec/requests/dashboard/maps_spec.rb
+++ b/spec/requests/dashboard/maps_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe "Maps", type: :request do
       end
 
       it "responds with a HTTP 200" do
-        patch dashboard_map_path(id: map.id, params: { map: sync_mode_true })
+        patch dashboard_map_path(id: map.id, params: { map: sync_mode_true }), as: :turbo_stream
         expect(response).to be_successful
       end
 
       it "updates sync mode in database" do
-        patch dashboard_map_path(id: map.id, params: { map: sync_mode_true })
+        patch dashboard_map_path(id: map.id, params: { map: sync_mode_true }), as: :turbo_stream
         expect(Map.find(map.id).sync_mode).to be true
       end
     end
@@ -54,12 +54,12 @@ RSpec.describe "Maps", type: :request do
       end
 
       it "responds with a HTTP 200" do
-        patch dashboard_map_path(id: map.id, params: { map: sync_mode_false })
+        patch dashboard_map_path(id: map.id, params: { map: sync_mode_false }), as: :turbo_stream
         expect(response).to be_successful
       end
 
       it "updates sync mode in database" do
-        patch dashboard_map_path(id: map.id, params: { map: sync_mode_false })
+        patch dashboard_map_path(id: map.id, params: { map: sync_mode_false }), as: :turbo_stream
         expect(Map.find(map.id).sync_mode).to be false
       end
     end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "Registrations", type: :request do
       }
     end
 
+    before do
+      @mapzy_cloud_env_before = ENV["MAPZY_CLOUD"]
+      ENV["MAPZY_CLOUD"] = "true" 
+    end
+
+    after do
+      ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before
+    end
+
     context "with valid user" do
       it "responds with a HTTP 302" do
         post user_registration_path(params: user_params)


### PR DESCRIPTION
This adds the ability to customize the colors of the pins, all locations button and the all locations close button. Also, I've improved the flash message logic so that flash messages can now be updated via Turbo Streams without the need to reload the page or to show error or success messages at random locations in the HTML (like it was before).

[Check out my screencast to see the custom colors in action!](https://share.cleanshot.com/0l1qh8Cj)

Screenshot of new Settings:
![CleanShot 2024-06-13 at 06 44 44@2x](https://github.com/mapzy/mapzy/assets/1881676/e6c21654-b9f3-4050-bb77-d48a4c5dd7fc)

Tests coming right up with the next commit

