### PR TITLE
Add translations for opening times and geocoder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,13 +12,13 @@ class ApplicationController < ActionController::Base
     locale = params[:language] || extract_locale_from_accept_language_header
 
     # fall back to english if the set locale is not available
-    locale = :en unless I18n.available_locales.include?(locale.to_sym)
+    locale = :en unless I18n.available_locales.include?(locale&.to_sym)
     I18n.with_locale(locale, &action)
   end
 
   private
 
   def extract_locale_from_accept_language_header
-    request.env["HTTP_ACCEPT_LANGUAGE"].scan(/^[a-z]{2}/).first
+    request.env["HTTP_ACCEPT_LANGUAGE"]&.scan(/^[a-z]{2}/)&.first
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,21 @@ class ApplicationController < ActionController::Base
   def mapzy_cloud?
     ENV["MAPZY_CLOUD"] == "true"
   end
+
+  # simple implementation based on rails docs: https://guides.rubyonrails.org/i18n.html#inferring-locale-from-the-language-header
+  def switch_locale(&action)
+    # if there's a locally in the embed params, use that, otherwise, use the language header
+
+    locale = params[:language] || extract_locale_from_accept_language_header
+
+    # fall back to english if the set locale is not available
+    locale = :en unless I18n.available_locales.include?(locale.to_sym)
+    I18n.with_locale(locale, &action)
+  end
+
+  private
+
+  def extract_locale_from_accept_language_header
+    request.env["HTTP_ACCEPT_LANGUAGE"].scan(/^[a-z]{2}/).first
+  end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -3,6 +3,8 @@
 class LocationsController < ApplicationController
   include Trackable
 
+  around_action :switch_locale, only: %i[show]
+
   before_action :set_map
   after_action -> { track_event("Viewed Location") }, only: %i[show]
 

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -3,6 +3,8 @@
 class MapsController < ApplicationController
   include Trackable
 
+  around_action :switch_locale, only: %i[show]
+
   after_action :allow_iframe, only: %i[show]
   after_action -> { track_event("Viewed Map", hashid: @map.hashid) }, only: %i[show]
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -9,8 +9,8 @@ export default class extends Controller {
     "dashboard": Boolean,
     "paramNoAccidentalZoom": Boolean,
     "customColor": String,
-    "customAccentColor": String
-    "locale": String,
+    "customAccentColor": String,
+    "locale": String
   }
 
   initialize() {

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     "paramNoAccidentalZoom": Boolean,
     "customColor": String,
     "customAccentColor": String
+    "locale": String,
   }
 
   initialize() {
@@ -72,6 +73,7 @@ export default class extends Controller {
           collapsed: false,
           marker: false,
           zoom: 15,
+          language: this.localeValue
         }),
         "top-right"
       );
@@ -85,7 +87,8 @@ export default class extends Controller {
       const locationId = feature.properties.hashid;
       const anchor = document.createElement("a");
 
-      anchor.href = `${this.locationBaseUrlValue}/${locationId}`;
+      anchor.href = `${this.locationBaseUrlValue}/${locationId}?language=${this.localeValue}`;
+
       anchor.setAttribute("data-turbo-frame", "side_panel");
       anchor.setAttribute("data-action", "side-panel#showPanel");
       anchor.setAttribute("data-location-id", locationId);

--- a/app/javascript/controllers/side_panel_controller.js
+++ b/app/javascript/controllers/side_panel_controller.js
@@ -5,11 +5,6 @@ export default class extends Controller {
     "panel"
   ]
 
-  static values = {
-    "customColor": String,
-    "customAccentColor": String
-  }
-
   hidePanel() {
     this.panelTarget.classList.add("hidden");
   }

--- a/app/models/opening_time.rb
+++ b/app/models/opening_time.rb
@@ -44,14 +44,13 @@ class OpeningTime < ApplicationRecord
   scope :weekend, -> { where(day: WEEKEND) }
 
   # Render the opening time
-  #
   def format_as_string
     if closed
-      "#{day.capitalize}: closed"
+      "#{I18n.t("days.#{day}")}: #{I18n.t('opening_times.closed')}"
     elsif open_24h
-      "#{day.capitalize}: open 24h"
+      "#{I18n.t("days.#{day}")}: #{I18n.t('opening_times.open_24h')}"
     elsif opens_at && closes_at
-      "#{day.capitalize}: #{opens_at.strftime('%H:%M')} - #{closes_at.strftime('%H:%M')}"
+      "#{I18n.t("days.#{day}")}: #{opens_at.strftime('%H:%M')} - #{closes_at.strftime('%H:%M')}"
     end
   end
 

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -9,9 +9,7 @@
   data-map-param-no-accidental-zoom-value="<%= params[:no_accidental_zoom] == "true" %>"
   data-map-custom-color-value="<%= @map.custom_color %>"
   data-map-custom-accent-color-value="<%= @map.custom_accent_color %>"
-  data-side-panel-custom-color-value="<%= @map.custom_color %>"
-  data-side-panel-custom-accent-color-value="<%= @map.custom_accent_color %>"
->
+  data-map-locale-value="<%= I18n.locale %>">
 
   <%= render "shared/mapbox" %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,9 @@ module Mapzy
 
     config.mission_control.jobs.base_controller_class = "MissionControlAdminController"
 
+    config.i18n.default_locale = :en
+    config.i18n.fallbacks = [:en]
+
     # Use Rspec as test framework
     config.generators do |g|
       g.test_framework :rspec,

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,12 @@
+de:
+  days:
+    monday: "Montag"
+    tuesday: "Dienstag"
+    wednesday: "Mittwoch"
+    thursday: "Donnerstag"
+    friday: "Freitag"
+    saturday: "Samstag"
+    sunday: "Sonntag"
+  opening_times:
+    closed: "Geschlossen"
+    open_24h: "Ganztags offen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,16 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  days:
+    monday: "Monday"
+    tuesday: "Tuesday"
+    wednesday: "Wednesday"
+    thursday: "Thursday"
+    friday: "Friday"
+    saturday: "Saturday"
+    sunday: "Sunday"
+  opening_times:
+    closed: "Closed"
+    open_24h: "Open 24h"
+
+

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,12 @@
+fr:
+  days:
+    monday: "Lundi"
+    tuesday: "Mardi"
+    wednesday: "Mercredi"
+    thursday: "Jeudi"
+    friday: "Vendredi"
+    saturday: "Samedi"
+    sunday: "Dimanche"
+  opening_times:
+    closed: "Fermé"
+    open_24h: "Ouvert 24h/24"

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -38,5 +38,11 @@ FactoryBot.define do
     longitude { 8.433332 }
 
     association :map
+
+    trait :with_opening_times do
+      after(:create) do |opening_time|
+        create_list(:opening_time, 7, location: opening_time)
+      end
+    end
   end
 end

--- a/spec/factories/opening_time.rb
+++ b/spec/factories/opening_time.rb
@@ -2,9 +2,8 @@
 
 FactoryBot.define do
   factory :opening_time do
-    # day { :monday }
     sequence :day, 0 do |n|
-      OpeningTime.days.keys[n]
+      OpeningTime.days.keys[n % 7]
     end
     opens_at { "08:00" }
     closes_at { "18:00" }

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "interacting with the map", type: :feature, js: true do
   end
 
   it "shows location view on pin click" do
-    page.scroll_to(page.find_link(href: map_location_path(map.hashid, location.hashid))).click
+    page.scroll_to(page.find_link(href: /#{map_location_path(map.hashid, location.hashid)}/)).click
     expect(page).to have_content(location.name)
   end
 end

--- a/spec/requests/dashboard/accounts_spec.rb
+++ b/spec/requests/dashboard/accounts_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Accounts", type: :request do
 
   before do
     @mapzy_cloud_env_before = ENV["MAPZY_CLOUD"]
-    ENV["MAPZY_CLOUD"] = "true" 
+    ENV["MAPZY_CLOUD"] = "true"
     sign_in user
   end
 
   after do
-    ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before
+    ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before # rubocop:disable RSpec/InstanceVariable
   end
 
   describe "GET /dashboard/settings" do
@@ -37,7 +37,7 @@ RSpec.describe "Accounts", type: :request do
         expect(response.body).to include("Main color")
       end
 
-       it "contains the accent color text" do
+      it "contains the accent color text" do
         expect(response.body).to include("Accent color")
       end
     end

--- a/spec/requests/dashboard/maps_spec.rb
+++ b/spec/requests/dashboard/maps_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Maps", type: :request do
 
       it "updates sync mode in database" do
         patch dashboard_map_path(id: map.id, params: { custom_color: "#000" }), as: :turbo_stream
-         expect(Map.find(map.id).custom_color).to eq("#000")
+        expect(Map.find(map.id).custom_color).to eq("#000")
       end
     end
 
@@ -97,8 +97,9 @@ RSpec.describe "Maps", type: :request do
       end
 
       it "updates sync mode in database" do
-        patch dashboard_map_path(id: map.id, params: { custom_accent_color: "#000" }), as: :turbo_stream
-         expect(Map.find(map.id).custom_accent_color).to eq("#000")
+        patch dashboard_map_path(id: map.id, params: { custom_accent_color: "#000" }),
+              as: :turbo_stream
+        expect(Map.find(map.id).custom_accent_color).to eq("#000")
       end
     end
   end

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Locations", type: :request do
   let(:map) { create(:map) }
   let(:location) { create(:location, :with_opening_times, map_id: map.id) }
-  #let(:opening_time) { create(:opening_time, day: 1, location: location ) }
+  # let(:opening_time) { create(:opening_time, day: 1, location: location ) }
 
   describe "GET locations/show" do
     context "with no language param" do
@@ -22,19 +22,18 @@ RSpec.describe "Locations", type: :request do
       end
     end
 
-    context "with no language param" do
+    context "with language param" do
       before do
-        get map_location_path(map.hashid, location.hashid), params: {language: "de"}
+        get map_location_path(map.hashid, location.hashid), params: { language: "de" }
       end
 
       it "responds with a HTTP 200" do
         expect(response).to be_successful
       end
 
-       it "contains opening times german" do
+      it "contains opening times german" do
         expect(response.body).to include("Montag")
       end
     end
-
   end
 end

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -4,15 +4,37 @@ require "rails_helper"
 
 RSpec.describe "Locations", type: :request do
   let(:map) { create(:map) }
-  let(:location) { create(:location, map_id: map.id) }
+  let(:location) { create(:location, :with_opening_times, map_id: map.id) }
+  #let(:opening_time) { create(:opening_time, day: 1, location: location ) }
 
   describe "GET locations/show" do
-    before do
-      get map_location_path(map.hashid, location.hashid)
+    context "with no language param" do
+      before do
+        get map_location_path(map.hashid, location.hashid)
+      end
+
+      it "responds with a HTTP 200" do
+        expect(response).to be_successful
+      end
+
+      it "contains opening times english (default)" do
+        expect(response.body).to include("Monday")
+      end
     end
 
-    it "responds with a HTTP 200" do
-      expect(response).to be_successful
+    context "with no language param" do
+      before do
+        get map_location_path(map.hashid, location.hashid), params: {language: "de"}
+      end
+
+      it "responds with a HTTP 200" do
+        expect(response).to be_successful
+      end
+
+       it "contains opening times german" do
+        expect(response.body).to include("Montag")
+      end
     end
+
   end
 end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe "Registrations", type: :request do
 
     before do
       @mapzy_cloud_env_before = ENV["MAPZY_CLOUD"]
-      ENV["MAPZY_CLOUD"] = "true" 
+      ENV["MAPZY_CLOUD"] = "true"
     end
 
     after do
-      ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before
+      ENV["MAPZY_CLOUD"] = @mapzy_cloud_env_before # rubocop:disable RSpec/InstanceVariable
     end
 
     context "with valid user" do


### PR DESCRIPTION
This PR adds translations for English, German and French for the opening times of Locations and for the Mapbox geocoder.

It allows to set a `language=` param when embedding the map:
- If the param is not set, it takes the locale from the `HTTP_ACCEPT_LANGUAGE` header from the user's browser
- If the locale is not one of the supported languages, it defaults to English
- The language parameter doesn't affect the Dashboard, only the public map view

[Check out this awesome screencast!](https://share.cleanshot.com/Q6kKRYvc)

Also updated [our docs](https://github.com/mapzy/mapzy/wiki/Embedding-options#set-language) to include the language option.